### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,18 @@
+name: Go
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `go vet` and `go test ./...`

## Testing
- `go vet ./...` *(fails: cannot use word as []string value)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_684824acd20c832fb5255b825104dd87