### PR TITLE
Fix UpperIndicator delimiter behavior

### DIFF
--- a/edge_cases_test.go
+++ b/edge_cases_test.go
@@ -86,10 +86,29 @@ func TestEdgeCases(t *testing.T) {
 		}
 
 		// Case B: Indicator != Delimiter
-		// With proposed fix, this should use the indicator as delimiter
+		// This should use the indicator as delimiter
 		res = ToFormattedCase(input, OptionDelimiter("-"), OptionUpperIndicator("="))
 		if res != "hello=world" {
 			t.Errorf("UpperIndicator Override: got %q, want %q", res, "hello=world")
+		}
+	})
+
+	// 5.1 UpperIndicator with MixCaseSupport (Consistency Check)
+	t.Run("UpperIndicator MixCase Consistency", func(t *testing.T) {
+		input := []Word{ExactCaseWord("helloWorld"), SingleCaseWord("foo")}
+
+		// Case A: Override behavior
+		// Expectation: hello=World=foo (UpperIndicator "=" overrides Delimiter "-")
+		res := ToFormattedCase(input, OptionDelimiter("-"), OptionUpperIndicator("="), OptionMixCaseSupport())
+		if res != "hello=World=foo" {
+			t.Errorf("UpperIndicator MixCase Override: got %q, want %q", res, "hello=World=foo")
+		}
+
+		// Case B: Double Delimiter behavior
+		// Expectation: hello--World--foo (UpperIndicator "-" matches Delimiter "-", so double delimiter)
+		res = ToFormattedCase(input, OptionDelimiter("-"), OptionUpperIndicator("-"), OptionMixCaseSupport())
+		if res != "hello--World--foo" {
+			t.Errorf("UpperIndicator MixCase Double: got %q, want %q", res, "hello--World--foo")
 		}
 	})
 

--- a/types.go
+++ b/types.go
@@ -205,6 +205,14 @@ func WordsToFormattedCase(words []Word, opts ...any) (string, error) {
 		}
 	}
 
+	if cfg.upperIndicator != "" {
+		if cfg.upperIndicator == cfg.delimiter {
+			cfg.delimiter = cfg.delimiter + cfg.delimiter
+		} else {
+			cfg.delimiter = cfg.upperIndicator
+		}
+	}
+
 	switch cfg.caseMode {
 	case CMScreaming:
 		cfg.screaming = true
@@ -280,15 +288,7 @@ func WordsToFormattedCase(words []Word, opts ...any) (string, error) {
 		result = append(result, w)
 	}
 
-	delimiter := cfg.delimiter
-	if cfg.upperIndicator != "" {
-		if cfg.upperIndicator == cfg.delimiter {
-			delimiter = cfg.delimiter + cfg.delimiter
-		} else {
-			delimiter = cfg.upperIndicator
-		}
-	}
-	final := strings.Join(result, delimiter)
+	final := strings.Join(result, cfg.delimiter)
 
 	if cfg.firstUpper {
 		final = UpperCaseFirst(final)


### PR DESCRIPTION
Refactor `WordsToFormattedCase` to calculate the effective delimiter early, ensuring `OptionUpperIndicator` consistently overrides or modifies the delimiter for both mixed-case splitting and final string joining. Updated `edge_cases_test.go` to remove outdated comments and verify consistency.

---
*PR created automatically by Jules for task [8071639884133601336](https://jules.google.com/task/8071639884133601336) started by @arran4*