### PR TITLE
ci: fix goreleaser git tag already exists error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
           go-version-file: go.mod
       - name: Tag commit for release (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
-        run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
+        run: git tag -f ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -382,7 +382,7 @@ jobs:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
-          git tag "$TAG"
+          git tag -f "$TAG"
           git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
       - name: Create release with generated notes + discussion
         env:


### PR DESCRIPTION
Fixes an issue where the GitHub Actions CI pipeline fails due to `git tag` returning a fatal error when a tag already exists locally. This often occurs during the release process when the tag is pushed to the remote by a concurrent job or a previous run. Added the `-f` flag to make `git tag` force update the local tag to handle such cases.

---
*PR created automatically by Jules for task [14348687602174658538](https://jules.google.com/task/14348687602174658538) started by @arran4*