### PR TITLE
Add DelimiterDetector to support custom multi-rune delimiters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+
+- When adding new features or types, always ensure you provide an example in the form of a testable 'ExampleXxx' function (like those in 'example_*_test.go') following standard Go conventions.
+- If a feature modifies parsing or formatting behavior, reflect the usage in the README.md to ensure users are aware of it.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ words = strings2.ParseSnakeCase("hello_world")
 
 // Configure parser
 words, err = strings2.Parse("N.E.W. World", strings2.ParserSmartAcronyms(true))
+
+// Custom multi-byte delimiters using DelimiterDetector
+partitioner := strings2.NewPartitioner(strings2.PartitionerConfig{
+	DelimiterDetector: func(subs []strings2.SubPart, index int) int {
+		if index+1 < len(subs) && subs[index].Rune() == ':' && subs[index+1].Rune() == ':' {
+			return 2 // matched "::"
+		}
+		return 0
+	},
+})
+words, err = strings2.Parse("foo::bar", partitioner)
 ```
 
 ### Case Conversion Functions

--- a/example_detector_test.go
+++ b/example_detector_test.go
@@ -1,0 +1,39 @@
+package strings2_test
+
+import (
+	"fmt"
+
+	"github.com/arran4/strings2"
+)
+
+func ExampleDelimiterDetector() {
+	input := "foo::bar--baz"
+
+	// Create a partitioner that looks for specific multi-rune sequences ("::" and "--")
+	partitioner := strings2.NewPartitioner(strings2.PartitionerConfig{
+		DelimiterDetector: func(subs []strings2.SubPart, index int) int {
+			// Look for double colon "::"
+			if index+1 < len(subs) && subs[index].Rune() == ':' && subs[index+1].Rune() == ':' {
+				return 2
+			}
+			// Look for double dash "--"
+			if index+1 < len(subs) && subs[index].Rune() == '-' && subs[index+1].Rune() == '-' {
+				return 2
+			}
+			return 0
+		},
+		PreserveSep: true,
+	})
+
+	words, _ := strings2.Parse(input, partitioner)
+	for i, w := range words {
+		fmt.Printf("Word %d: %T %q\n", i, w, w.String())
+	}
+
+	// Output:
+	// Word 0: strings2.SingleCaseWord "foo"
+	// Word 1: strings2.SeparatorWord "::"
+	// Word 2: strings2.SingleCaseWord "bar"
+	// Word 3: strings2.SeparatorWord "--"
+	// Word 4: strings2.SingleCaseWord "baz"
+}

--- a/parts.go
+++ b/parts.go
@@ -91,6 +91,12 @@ func NewPartitioner(cfg PartitionerConfig) Partitioner {
 			delimLen := 0
 			if cfg.DelimiterDetector != nil {
 				delimLen = cfg.DelimiterDetector(subs, i)
+				if delimLen < 0 {
+					delimLen = 0
+				}
+				if delimLen > len(subs)-i {
+					delimLen = len(subs) - i
+				}
 			}
 			if delimLen == 0 && cfg.Delimiters != nil && cfg.Delimiters[s.Rune()] {
 				delimLen = 1

--- a/parts.go
+++ b/parts.go
@@ -65,9 +65,16 @@ func CamelCasePartitioner(subs []SubPart) []Part {
 	})(subs)
 }
 
+
+// DelimiterDetector detects if a delimiter starts at the given index in subs.
+// It returns the length of the delimiter in subparts (runes), or 0 if no delimiter is found.
+type DelimiterDetector func(subs []SubPart, index int) (length int)
+
 type PartitionerConfig struct {
-	Delimiters  map[rune]bool
-	SplitCamel  bool
+	Delimiters        map[rune]bool
+	DelimiterDetector DelimiterDetector
+	SplitCamel        bool
+
 	NumberMode  NumberMode
 	PreserveSep bool // If true, delimiters are returned as SeparatorPart instead of discarded
 }
@@ -78,23 +85,34 @@ func NewPartitioner(cfg PartitionerConfig) Partitioner {
 		var parts []Part
 		var current []SubPart
 
-		for i, s := range subs {
-			// Check if current rune is a delimiter
-			if cfg.Delimiters != nil && cfg.Delimiters[s.Rune()] {
+		for i := 0; i < len(subs); {
+			s := subs[i]
+
+			delimLen := 0
+			if cfg.DelimiterDetector != nil {
+				delimLen = cfg.DelimiterDetector(subs, i)
+			}
+			if delimLen == 0 && cfg.Delimiters != nil && cfg.Delimiters[s.Rune()] {
+				delimLen = 1
+			}
+
+			// Check if current rune(s) is a delimiter
+			if delimLen > 0 {
 				if len(current) > 0 {
 					parts = append(parts, &WordPart{BasePart{Subs: current}})
 					current = nil
 				}
 				if cfg.PreserveSep {
-					parts = append(parts, &SeparatorPart{BasePart{Subs: []SubPart{s}}})
+					parts = append(parts, &SeparatorPart{BasePart{Subs: subs[i : i+delimLen]}})
 				}
+				i += delimLen
 				continue
 			}
 
 			// Transition check
 			isSplit := false
-			if (cfg.SplitCamel || cfg.NumberMode != NumberModeNone) && i > 0 && len(current) > 0 {
-				prev := subs[i-1]
+			if (cfg.SplitCamel || cfg.NumberMode != NumberModeNone) && len(current) > 0 {
+				prev := current[len(current)-1]
 				// Note: if prev was delimiter, current is empty or started anew.
 				// We rely on current being non-empty to check transitions within a word chunk.
 
@@ -153,6 +171,7 @@ func NewPartitioner(cfg PartitionerConfig) Partitioner {
 				}
 			}
 			current = append(current, s)
+			i++
 		}
 		if len(current) > 0 {
 			parts = append(parts, &WordPart{BasePart{Subs: current}})

--- a/parts_test.go
+++ b/parts_test.go
@@ -39,3 +39,88 @@ func TestCamelCasePartitioner(t *testing.T) {
 		t.Errorf("Part 1 mismatch: %s", parts[1].String())
 	}
 }
+
+func TestDelimiterDetector(t *testing.T) {
+	input := "foo::bar--baz"
+	subs, _ := strings2.StringToSubParts(input)
+
+	partitioner := strings2.NewPartitioner(strings2.PartitionerConfig{
+		DelimiterDetector: func(subs []strings2.SubPart, index int) int {
+			if index+1 < len(subs) && subs[index].Rune() == ':' && subs[index+1].Rune() == ':' {
+				return 2
+			}
+			if index+1 < len(subs) && subs[index].Rune() == '-' && subs[index+1].Rune() == '-' {
+				return 2
+			}
+			return 0
+		},
+		PreserveSep: true,
+	})
+
+	parts := strings2.SubPartsToParts(subs, partitioner)
+	if len(parts) != 5 {
+		t.Fatalf("Expected 5 parts, got %d", len(parts))
+	}
+	if parts[0].String() != "foo" {
+		t.Errorf("Part 0 mismatch: %s", parts[0].String())
+	}
+	if parts[1].String() != "::" {
+		t.Errorf("Part 1 mismatch: %s", parts[1].String())
+	}
+	if parts[2].String() != "bar" {
+		t.Errorf("Part 2 mismatch: %s", parts[2].String())
+	}
+	if parts[3].String() != "--" {
+		t.Errorf("Part 3 mismatch: %s", parts[3].String())
+	}
+	if parts[4].String() != "baz" {
+		t.Errorf("Part 4 mismatch: %s", parts[4].String())
+	}
+}
+
+func TestDelimiterDetectorOutOfBounds(t *testing.T) {
+	input := "foo"
+	subs, _ := strings2.StringToSubParts(input)
+
+	partitioner := strings2.NewPartitioner(strings2.PartitionerConfig{
+		DelimiterDetector: func(subs []strings2.SubPart, index int) int {
+			// Malicious detector that returns a length larger than the slice
+			return 100
+		},
+		PreserveSep: true,
+	})
+
+	// Should not panic, but return separator of constrained length
+	parts := strings2.SubPartsToParts(subs, partitioner)
+	if len(parts) != 1 {
+		t.Fatalf("Expected 1 part, got %d", len(parts))
+	}
+	if parts[0].String() != "foo" {
+		t.Errorf("Part 0 mismatch: %s", parts[0].String())
+	}
+	// "foo" is returned as a SeparatorPart because the detector claims it's a delimiter,
+	// and the length is constrained to len(subs) - i = 3
+	if _, ok := parts[0].(*strings2.SeparatorPart); !ok {
+		t.Errorf("Expected SeparatorPart for malicious length, got %T", parts[0])
+	}
+}
+
+func TestDelimiterDetectorNegativeBounds(t *testing.T) {
+	input := "foo"
+	subs, _ := strings2.StringToSubParts(input)
+
+	partitioner := strings2.NewPartitioner(strings2.PartitionerConfig{
+		DelimiterDetector: func(subs []strings2.SubPart, index int) int {
+			return -100
+		},
+	})
+
+	// Should not panic, should act as length 0
+	parts := strings2.SubPartsToParts(subs, partitioner)
+	if len(parts) != 1 {
+		t.Fatalf("Expected 1 part, got %d", len(parts))
+	}
+	if parts[0].String() != "foo" {
+		t.Errorf("Part 0 mismatch: %s", parts[0].String())
+	}
+}


### PR DESCRIPTION
Implemented `DelimiterDetector` in `PartitionerConfig` to support dynamically identifying complex delimiters (e.g., multi-rune delimiters) natively and efficiently.
- Changed the `NewPartitioner` iteration from `range` to a manual `for` loop to jump lengths when a multi-rune delimiter matches.
- Evaluated `DelimiterDetector` before the fallback to `Delimiters` map.
- Kept previous functionality intact for backward compatibility.

---
*PR created automatically by Jules for task [14995039502551171691](https://jules.google.com/task/14995039502551171691) started by @arran4*