### PR TITLE
feat: Add OptionWhispering and OptionScreaming

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -69,7 +69,7 @@ func BenchmarkToKebabCase(b *testing.B) {
 
 func BenchmarkToKebabCase_WithOptions(b *testing.B) {
 	b.ReportAllocs()
-	opts := []Option{OptionCaseMode(CMScreaming), OptionUpperIndicator("--")}
+	opts := []Option{OptionScreaming(), OptionUpperIndicator("--")}
 	for i := 0; i < b.N; i++ {
 		_, _ = ToKebabCase(benchWords, opts...)
 	}
@@ -78,7 +78,7 @@ func BenchmarkToKebabCase_WithOptions(b *testing.B) {
 func BenchmarkToKebabCase_WithManyOptions(b *testing.B) {
 	b.ReportAllocs()
 	opts := []Option{
-		OptionCaseMode(CMScreaming),
+		OptionScreaming(),
 		OptionUpperIndicator("--"),
 		OptionFirstUpper(),
 		OptionFirstLower(),
@@ -97,7 +97,7 @@ func BenchmarkToFormattedCase_Screaming(b *testing.B) {
 		SingleCaseWord("a"),
 		SingleCaseWord("test"),
 	}
-	opts := []Option{OptionCaseMode(CMScreaming)}
+	opts := []Option{OptionScreaming()}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -114,7 +114,7 @@ func BenchmarkToFormattedCase_Screaming_Mixed(b *testing.B) {
 		SingleCaseWord("A"),
 		SingleCaseWord("TeSt"),
 	}
-	opts := []Option{OptionCaseMode(CMScreaming)}
+	opts := []Option{OptionScreaming()}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -131,7 +131,7 @@ func BenchmarkToFormattedCase_Whispering(b *testing.B) {
 		SingleCaseWord("A"),
 		SingleCaseWord("TEST"),
 	}
-	opts := []Option{OptionCaseMode(CMWhispering)}
+	opts := []Option{OptionWhispering()}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/comparison_test.go
+++ b/comparison_test.go
@@ -145,7 +145,7 @@ func getFormatOptions(provider, format string) []Option {
 	isSnake := format == "Snake" || format == "Kebab" || format == "Delimited" // Kebab and Delimited usually follow snake rules for casing
 	if isSnake {
 		if provider == "iancoleman" || provider == "ettle" || provider == "golang-cz" || provider == "tomedharris" || provider == "janos" {
-			opts = append(opts, OptionCaseMode(CMWhispering))
+			opts = append(opts, OptionWhispering())
 		}
 	}
 	return opts
@@ -170,11 +170,11 @@ func TestComparisons(t *testing.T) {
 					got, err = ToSnakeCase(words, opts...)
 				}
 			case "ScreamingSnake":
-				got, err = ToSnakeCase(words, append(opts, OptionCaseMode(CMScreaming))...)
+				got, err = ToSnakeCase(words, append(opts, OptionScreaming())...)
 			case "Kebab":
 				got, err = ToKebabCase(words, opts...)
 			case "ScreamingKebab":
-				got, err = ToKebabCase(words, append(opts, OptionCaseMode(CMScreaming))...)
+				got, err = ToKebabCase(words, append(opts, OptionScreaming())...)
 			case "Camel":
 				got, err = ToCamelCase(words, opts...)
 			case "Pascal":

--- a/edge_cases_test.go
+++ b/edge_cases_test.go
@@ -205,8 +205,8 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToSnake,
 			perms: []Permutation{
 				{"default behavior (CMVerbatim)", nil, "hello_World"},
-				{"strcase parity (CMWhispering)", []any{OptionCaseMode(CMWhispering)}, "hello_world"},
-				{"screaming case", []any{OptionCaseMode(CMScreaming)}, "HELLO_WORLD"},
+				{"strcase parity (CMWhispering)", []any{OptionWhispering()}, "hello_world"},
+				{"screaming case", []any{OptionScreaming()}, "HELLO_WORLD"},
 			},
 		},
 		{
@@ -215,7 +215,7 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToSnake,
 			perms: []Permutation{
 				{"default behavior", nil, "hello_world"},
-				{"strcase parity", []any{OptionCaseMode(CMWhispering), ParserEmitEmpty(true)}, "__hello_world"},
+				{"strcase parity", []any{OptionWhispering(), ParserEmitEmpty(true)}, "__hello_world"},
 			},
 		},
 		{
@@ -224,7 +224,7 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToSnake,
 			perms: []Permutation{
 				{"default behavior", nil, "hello_world"},
-				{"strcase parity", []any{OptionCaseMode(CMWhispering), ParserEmitEmpty(true)}, "hello_world__"},
+				{"strcase parity", []any{OptionWhispering(), ParserEmitEmpty(true)}, "hello_world__"},
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToSnake,
 			perms: []Permutation{
 				{"default behavior", nil, "HTTP_Response"},
-				{"strcase parity", []any{OptionCaseMode(CMWhispering)}, "http_response"},
+				{"strcase parity", []any{OptionWhispering()}, "http_response"},
 				{"disable smart acronyms", []any{ParserSmartAcronyms(false)}, "HTTP_Response"},
 			},
 		},
@@ -243,7 +243,7 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToKebab,
 			perms: []Permutation{
 				{"default behavior", nil, "hello-World"},
-				{"strcase parity", []any{OptionCaseMode(CMWhispering)}, "hello-world"},
+				{"strcase parity", []any{OptionWhispering()}, "hello-world"},
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func TestIancolemanMismatchesAndPermutations(t *testing.T) {
 			fn:    ToFormattedString, // Requires at least a delimiter option
 			perms: []Permutation{
 				{"default behavior with delimiter", []any{OptionDelimiter("_")}, "hello_World"},
-				{"strcase parity", []any{OptionDelimiter("_"), OptionCaseMode(CMWhispering)}, "hello_world"},
+				{"strcase parity", []any{OptionDelimiter("_"), OptionWhispering()}, "hello_world"},
 			},
 		},
 	}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -33,10 +33,10 @@ func TestOptionMetadata(t *testing.T) {
 		{
 			name: "Case Mode Screaming",
 			options: []Option{
-				OptionCaseMode(CMScreaming),
+				OptionScreaming(),
 			},
 			expected: caseConfig{
-				caseMode:  CMScreaming,
+				screaming: true,
 				delimiter: "-",
 			},
 		},
@@ -94,12 +94,12 @@ func TestOptionMetadata(t *testing.T) {
 			name: "Combination",
 			options: []Option{
 				OptionDelimiter("."),
-				OptionCaseMode(CMWhispering),
+				OptionWhispering(),
 				OptionFirstUpper(),
 			},
 			expected: caseConfig{
 				delimiter:  ".",
-				caseMode:   CMWhispering,
+				whispering: true,
 				firstUpper: true,
 			},
 		},
@@ -167,7 +167,7 @@ func TestCircularConsistency(t *testing.T) {
 			name:      "Screaming Snake",
 			input:     "HELLO_WORLD",
 			delimiter: "_",
-			options:   []Option{OptionDelimiter("_"), OptionCaseMode(CMScreaming)},
+			options:   []Option{OptionDelimiter("_"), OptionScreaming()},
 		},
 		{
 			name:      "Pascal Case (treated as exact words joined by empty)",
@@ -237,7 +237,7 @@ func TestInternalFlagsConsistency(t *testing.T) {
 	// Case 1: CMScreaming sets cfg.screaming = true.
 	// SingleCaseWord should be Uppercased.
 	t.Run("CMScreaming implies screaming", func(t *testing.T) {
-		res := ToFormattedCase([]Word{SingleCaseWord("hello")}, OptionCaseMode(CMScreaming))
+		res := ToFormattedCase([]Word{SingleCaseWord("hello")}, OptionScreaming())
 		if res != "HELLO" {
 			t.Errorf("CMScreaming did not result in screaming output: %q", res)
 		}
@@ -246,7 +246,7 @@ func TestInternalFlagsConsistency(t *testing.T) {
 	// Case 2: CMWhispering implies whispering.
 	// SingleCaseWord should be Lowercased (even if input is upper).
 	t.Run("CMWhispering implies whispering", func(t *testing.T) {
-		res := ToFormattedCase([]Word{SingleCaseWord("HELLO")}, OptionCaseMode(CMWhispering))
+		res := ToFormattedCase([]Word{SingleCaseWord("HELLO")}, OptionWhispering())
 		if res != "hello" {
 			t.Errorf("CMWhispering did not result in whispering output: %q", res)
 		}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -36,7 +36,7 @@ func TestOptionMetadata(t *testing.T) {
 				OptionScreaming(),
 			},
 			expected: caseConfig{
-				screaming: true,
+				caseMode:  CMScreaming,
 				delimiter: "-",
 			},
 		},
@@ -99,7 +99,7 @@ func TestOptionMetadata(t *testing.T) {
 			},
 			expected: caseConfig{
 				delimiter:  ".",
-				whispering: true,
+				caseMode:   CMWhispering,
 				firstUpper: true,
 			},
 		},

--- a/optimization_test.go
+++ b/optimization_test.go
@@ -24,13 +24,13 @@ func TestOptimizationCorrectness(t *testing.T) {
 		{
 			name:     "MixedCase Screaming",
 			input:    []Word{SingleCaseWord("HeLLo"), SingleCaseWord("WoRLd")},
-			options:  []Option{OptionDelimiter("-"), OptionCaseMode(CMScreaming)},
+			options:  []Option{OptionDelimiter("-"), OptionScreaming()},
 			expected: "HELLO-WORLD",
 		},
 		{
 			name:     "MixedCase Whispering",
 			input:    []Word{SingleCaseWord("HeLLo"), SingleCaseWord("WoRLd")},
-			options:  []Option{OptionDelimiter("-"), OptionCaseMode(CMWhispering)},
+			options:  []Option{OptionDelimiter("-"), OptionWhispering()},
 			expected: "hello-world",
 		},
 		{

--- a/types.go
+++ b/types.go
@@ -288,12 +288,12 @@ func OptionCaseMode(caseMode CaseMode) Option {
 
 // OptionWhispering ensures all characters are lowercase.
 func OptionWhispering() Option {
-	return func(cfg *caseConfig) { cfg.whispering = true }
+	return func(cfg *caseConfig) { cfg.caseMode = CMWhispering }
 }
 
 // OptionScreaming ensures all characters are uppercase.
 func OptionScreaming() Option {
-	return func(cfg *caseConfig) { cfg.screaming = true }
+	return func(cfg *caseConfig) { cfg.caseMode = CMScreaming }
 }
 
 // OptionFirstUpper ensures the very first character of the result is uppercase.

--- a/types.go
+++ b/types.go
@@ -286,6 +286,16 @@ func OptionCaseMode(caseMode CaseMode) Option {
 	return func(cfg *caseConfig) { cfg.caseMode = caseMode }
 }
 
+// OptionWhispering ensures all characters are lowercase.
+func OptionWhispering() Option {
+	return func(cfg *caseConfig) { cfg.whispering = true }
+}
+
+// OptionScreaming ensures all characters are uppercase.
+func OptionScreaming() Option {
+	return func(cfg *caseConfig) { cfg.screaming = true }
+}
+
 // OptionFirstUpper ensures the very first character of the result is uppercase.
 func OptionFirstUpper() Option {
 	return func(cfg *caseConfig) { cfg.firstUpper = true }

--- a/types_test.go
+++ b/types_test.go
@@ -108,7 +108,7 @@ func TestToKebabCase(t *testing.T) {
 				SingleCaseWord("hello"),
 				SingleCaseWord("world"),
 			},
-			options:  []Option{OptionCaseMode(CMScreaming)},
+			options:  []Option{OptionScreaming()},
 			expected: "HELLO-WORLD",
 		},
 		{
@@ -153,7 +153,7 @@ func TestToSnakeCase(t *testing.T) {
 				SingleCaseWord("hello"),
 				SingleCaseWord("world"),
 			},
-			options:  []Option{OptionCaseMode(CMScreaming)},
+			options:  []Option{OptionScreaming()},
 			expected: "HELLO_WORLD",
 		},
 		{


### PR DESCRIPTION
This PR implements `OptionWhispering` and `OptionScreaming` as native Option functions to directly enable the whispering (lowercase all characters) and screaming (uppercase all characters) casing behaviours. This allows for cleaner API usage than using `OptionCaseMode(CMWhispering)` and standardizes with other options. Included tests updates.

---
*PR created automatically by Jules for task [9476903220803308771](https://jules.google.com/task/9476903220803308771) started by @arran4*