### PR TITLE
feat: Add WithNonAlphanumericAsDelimiter option to parser

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -59,7 +59,7 @@ func process(input string, output string, args []string, fn func(string, ...any)
 	fmt.Fprintln(out, res)
 }
 
-func buildOpts(delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool) []any {
+func buildOpts(delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool) []any {
 	var opts []any
 	if delimiter != "" {
 		opts = append(opts, strings2.OptionDelimiter(delimiter))
@@ -85,6 +85,9 @@ func buildOpts(delimiter string, screaming bool, whispering bool, firstUpper boo
 	}
 	if numberSplitting {
 		opts = append(opts, strings2.WithNumberSplitting(true))
+	}
+	if nonAlphanumeric {
+		opts = append(opts, strings2.WithNonAlphanumericAsDelimiter(true))
 	}
 	var allAcronyms []string
 	if len(acronym) > 0 {
@@ -132,15 +135,17 @@ func buildOpts(delimiter string, screaming bool, whispering bool, firstUpper boo
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Camel(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Camel(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToCamel, opts...)
 }
 
@@ -155,15 +160,17 @@ func Camel(input string, output string, delimiter string, screaming bool, whispe
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Snake(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Snake(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToSnake, opts...)
 }
 
@@ -178,15 +185,17 @@ func Snake(input string, output string, delimiter string, screaming bool, whispe
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Kebab(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Kebab(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToKebab, opts...)
 }
 
@@ -201,15 +210,17 @@ func Kebab(input string, output string, delimiter string, screaming bool, whispe
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Pascal(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Pascal(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToPascal, opts...)
 }
 
@@ -224,15 +235,17 @@ func Pascal(input string, output string, delimiter string, screaming bool, whisp
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Darwin(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Darwin(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToDarwin, opts...)
 }
 
@@ -247,15 +260,17 @@ func Darwin(input string, output string, delimiter string, screaming bool, whisp
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Title(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Title(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToTitle, opts...)
 }
 
@@ -270,15 +285,17 @@ func Title(input string, output string, delimiter string, screaming bool, whispe
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func LowerCamel(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func LowerCamel(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToLowerCamel, opts...)
 }
 
@@ -293,15 +310,17 @@ func LowerCamel(input string, output string, delimiter string, screaming bool, w
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func ScreamingSnake(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func ScreamingSnake(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToScreamingSnake, opts...)
 }
 
@@ -316,15 +335,17 @@ func ScreamingSnake(input string, output string, delimiter string, screaming boo
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func ScreamingKebab(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func ScreamingKebab(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	process(input, output, args, strings2.ToScreamingKebab, opts...)
 }
 
@@ -339,15 +360,17 @@ func ScreamingKebab(input string, output string, delimiter string, screaming boo
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Delimited(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Delimited(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	del := uint8('.')
 	if len(delimiter) > 0 {
 		del = delimiter[0]
@@ -369,15 +392,17 @@ func Delimited(input string, output string, delimiter string, screaming bool, wh
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	mixCaseSupport: -m --mix-case-support (default: false) Mix case support
 //	noSmartAcronyms: --no-smart-acronyms (default: false) Disable smart acronyms
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func ScreamingDelimited(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func ScreamingDelimited(input string, output string, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, mixCaseSupport bool, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, mixCaseSupport, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	del := uint8('.')
 	if len(delimiter) > 0 {
 		del = delimiter[0]
@@ -485,10 +510,11 @@ func getIO(input, output string, args []string) (io.Reader, io.Writer) {
 //	acronym: --acronym (default: []) Acronym to preserve case
 //	acronymFromFile: --acronym-from-file (default: []) File containing acronyms to preserve case
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Words(input string, output string, jsonOut bool, delimiter string, noSmartAcronyms bool, numberSplitting bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
-	opts := buildOpts(delimiter, false, false, false, false, false, noSmartAcronyms, numberSplitting, acronym, acronymFromFile, strict)
+func Words(input string, output string, jsonOut bool, delimiter string, noSmartAcronyms bool, numberSplitting bool, nonAlphanumeric bool, acronym []string, acronymFromFile []string, strict bool, args ...string) {
+	opts := buildOpts(delimiter, false, false, false, false, false, noSmartAcronyms, numberSplitting, nonAlphanumeric, acronym, acronymFromFile, strict)
 	if delimiter != "" {
 		r, _ := utf8.DecodeRuneInString(delimiter)
 		numMode := strings2.NumberModeNone
@@ -496,33 +522,10 @@ func Words(input string, output string, jsonOut bool, delimiter string, noSmartA
 			numMode = strings2.NumberModeSplitAlways
 		}
 		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
-		}))
-	}
-	if delimiter != "" {
-		r, _ := utf8.DecodeRuneInString(delimiter)
-		numMode := strings2.NumberModeNone
-		if numberSplitting {
-			numMode = strings2.NumberModeSplitAlways
-		}
-		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
-		}))
-	}
-	if delimiter != "" {
-		r, _ := utf8.DecodeRuneInString(delimiter)
-		numMode := strings2.NumberModeNone
-		if numberSplitting {
-			numMode = strings2.NumberModeSplitAlways
-		}
-		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
+			Delimiters:                 map[rune]bool{r: true},
+			SplitCamel:                 true,
+			NumberMode:                 numMode,
+			NonAlphanumericAsDelimiter: nonAlphanumeric,
 		}))
 	}
 
@@ -557,10 +560,11 @@ func Words(input string, output string, jsonOut bool, delimiter string, noSmartA
 //	jsonOut: --json (default: false) Output as JSON
 //	delimiter: -d --delimiter (default: "") Delimiter
 //	numberSplitting: --number-splitting (default: false) Enable number splitting
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func Parts(input string, output string, jsonOut bool, delimiter string, numberSplitting bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, false, false, false, false, false, false, numberSplitting, nil, nil, strict)
+func Parts(input string, output string, jsonOut bool, delimiter string, numberSplitting bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, false, false, false, false, false, false, numberSplitting, nonAlphanumeric, nil, nil, strict)
 	if delimiter != "" {
 		r, _ := utf8.DecodeRuneInString(delimiter)
 		numMode := strings2.NumberModeNone
@@ -568,33 +572,10 @@ func Parts(input string, output string, jsonOut bool, delimiter string, numberSp
 			numMode = strings2.NumberModeSplitAlways
 		}
 		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
-		}))
-	}
-	if delimiter != "" {
-		r, _ := utf8.DecodeRuneInString(delimiter)
-		numMode := strings2.NumberModeNone
-		if numberSplitting {
-			numMode = strings2.NumberModeSplitAlways
-		}
-		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
-		}))
-	}
-	if delimiter != "" {
-		r, _ := utf8.DecodeRuneInString(delimiter)
-		numMode := strings2.NumberModeNone
-		if numberSplitting {
-			numMode = strings2.NumberModeSplitAlways
-		}
-		opts = append(opts, strings2.NewPartitioner(strings2.PartitionerConfig{
-			Delimiters: map[rune]bool{r: true},
-			SplitCamel: true,
-			NumberMode: numMode,
+			Delimiters:                 map[rune]bool{r: true},
+			SplitCamel:                 true,
+			NumberMode:                 numMode,
+			NonAlphanumericAsDelimiter: nonAlphanumeric,
 		}))
 	}
 
@@ -717,10 +698,11 @@ func processWordsTo(input string, output string, args []string, jsonInput bool, 
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToCamel(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToCamel(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToCamelCase, opts...)
 }
 
@@ -736,10 +718,11 @@ func WordsToCamel(input string, output string, jsonInput bool, delimiter string,
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToSnake(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToSnake(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToSnakeCase, opts...)
 }
 
@@ -755,10 +738,11 @@ func WordsToSnake(input string, output string, jsonInput bool, delimiter string,
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToKebab(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToKebab(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToKebabCase, opts...)
 }
 
@@ -774,10 +758,11 @@ func WordsToKebab(input string, output string, jsonInput bool, delimiter string,
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToPascal(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToPascal(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToPascalCase, opts...)
 }
 
@@ -793,10 +778,11 @@ func WordsToPascal(input string, output string, jsonInput bool, delimiter string
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToDarwin(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToDarwin(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToDarwinCase, opts...)
 }
 
@@ -812,9 +798,10 @@ func WordsToDarwin(input string, output string, jsonInput bool, delimiter string
 //	whispering: -w --whispering (default: false) Whispering mode
 //	firstUpper: -U --first-upper (default: false) First char upper
 //	firstLower: -l --first-lower (default: false) First char lower
+//	nonAlphanumeric: -N --non-alphanumeric (default: false) Treat non-alphanumeric characters as delimiters
 //	strict: --strict (default: false) Strict UTF8 mode
 //	args: ... String to convert if file/stdin not provided
-func WordsToTitle(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, strict bool, args ...string) {
-	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nil, nil, strict)
+func WordsToTitle(input string, output string, jsonInput bool, delimiter string, screaming bool, whispering bool, firstUpper bool, firstLower bool, nonAlphanumeric bool, strict bool, args ...string) {
+	opts := buildOpts(delimiter, screaming, whispering, firstUpper, firstLower, false, false, false, nonAlphanumeric, nil, nil, strict)
 	processWordsTo(input, output, args, jsonInput, strings2.FromWordsToTitleCase, opts...)
 }

--- a/cmd/strings2/camel.go
+++ b/cmd/strings2/camel.go
@@ -27,6 +27,7 @@ type Camel struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Camel) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewCamel() *Camel {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Camel) error {
 
-		cli.Camel(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Camel(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/camel_test.go
+++ b/cmd/strings2/camel_test.go
@@ -35,6 +35,7 @@ func TestCamel_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestCamel_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/darwin.go
+++ b/cmd/strings2/darwin.go
@@ -27,6 +27,7 @@ type Darwin struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Darwin) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewDarwin() *Darwin {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Darwin) error {
 
-		cli.Darwin(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Darwin(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/darwin_test.go
+++ b/cmd/strings2/darwin_test.go
@@ -35,6 +35,7 @@ func TestDarwin_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestDarwin_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/delimited.go
+++ b/cmd/strings2/delimited.go
@@ -27,6 +27,7 @@ type Delimited struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Delimited) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewDelimited() *Delimited {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Delimited) error {
 
-		cli.Delimited(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Delimited(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/delimited_test.go
+++ b/cmd/strings2/delimited_test.go
@@ -35,6 +35,7 @@ func TestDelimited_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestDelimited_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/kebab.go
+++ b/cmd/strings2/kebab.go
@@ -27,6 +27,7 @@ type Kebab struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Kebab) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewKebab() *Kebab {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Kebab) error {
 
-		cli.Kebab(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Kebab(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/kebab_test.go
+++ b/cmd/strings2/kebab_test.go
@@ -35,6 +35,7 @@ func TestKebab_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestKebab_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/lowercamel.go
+++ b/cmd/strings2/lowercamel.go
@@ -27,6 +27,7 @@ type Lowercamel struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Lowercamel) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewLowercamel() *Lowercamel {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Lowercamel) error {
 
-		cli.LowerCamel(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.LowerCamel(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/lowercamel_test.go
+++ b/cmd/strings2/lowercamel_test.go
@@ -35,6 +35,7 @@ func TestLowercamel_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestLowercamel_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/parts.go
+++ b/cmd/strings2/parts.go
@@ -22,6 +22,7 @@ type Parts struct {
 	jsonOut         bool
 	delimiter       string
 	numberSplitting bool
+	nonAlphanumeric bool
 	strict          bool
 	args            []string
 	SubCommands     map[string]Cmd
@@ -128,6 +129,17 @@ func (c *Parts) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -190,12 +202,16 @@ func (c *RootCmd) NewParts() *Parts {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Parts) error {
 
-		cli.Parts(c.input, c.output, c.jsonOut, c.delimiter, c.numberSplitting, c.strict, c.args...)
+		cli.Parts(c.input, c.output, c.jsonOut, c.delimiter, c.numberSplitting, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/parts_test.go
+++ b/cmd/strings2/parts_test.go
@@ -30,6 +30,7 @@ func TestParts_Execute(t *testing.T) {
 	args = append(args, "--delimiter")
 	args = append(args, "test")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -54,6 +55,9 @@ func TestParts_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/pascal.go
+++ b/cmd/strings2/pascal.go
@@ -27,6 +27,7 @@ type Pascal struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Pascal) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewPascal() *Pascal {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Pascal) error {
 
-		cli.Pascal(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Pascal(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/pascal_test.go
+++ b/cmd/strings2/pascal_test.go
@@ -35,6 +35,7 @@ func TestPascal_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestPascal_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/screamingdelimited.go
+++ b/cmd/strings2/screamingdelimited.go
@@ -27,6 +27,7 @@ type Screamingdelimited struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Screamingdelimited) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewScreamingdelimited() *Screamingdelimited {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Screamingdelimited) error {
 
-		cli.ScreamingDelimited(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.ScreamingDelimited(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/screamingdelimited_test.go
+++ b/cmd/strings2/screamingdelimited_test.go
@@ -35,6 +35,7 @@ func TestScreamingdelimited_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestScreamingdelimited_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/screamingkebab.go
+++ b/cmd/strings2/screamingkebab.go
@@ -27,6 +27,7 @@ type Screamingkebab struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Screamingkebab) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewScreamingkebab() *Screamingkebab {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Screamingkebab) error {
 
-		cli.ScreamingKebab(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.ScreamingKebab(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/screamingkebab_test.go
+++ b/cmd/strings2/screamingkebab_test.go
@@ -35,6 +35,7 @@ func TestScreamingkebab_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestScreamingkebab_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/screamingsnake.go
+++ b/cmd/strings2/screamingsnake.go
@@ -27,6 +27,7 @@ type Screamingsnake struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Screamingsnake) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewScreamingsnake() *Screamingsnake {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Screamingsnake) error {
 
-		cli.ScreamingSnake(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.ScreamingSnake(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/screamingsnake_test.go
+++ b/cmd/strings2/screamingsnake_test.go
@@ -35,6 +35,7 @@ func TestScreamingsnake_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestScreamingsnake_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/snake.go
+++ b/cmd/strings2/snake.go
@@ -27,6 +27,7 @@ type Snake struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Snake) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewSnake() *Snake {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Snake) error {
 
-		cli.Snake(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Snake(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/snake_test.go
+++ b/cmd/strings2/snake_test.go
@@ -35,6 +35,7 @@ func TestSnake_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestSnake_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/templates/camel_usage.txt
+++ b/cmd/strings2/templates/camel_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/darwin_usage.txt
+++ b/cmd/strings2/templates/darwin_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/delimited_usage.txt
+++ b/cmd/strings2/templates/delimited_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string         (default: ".")     Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                   (default: ".")     Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/kebab_usage.txt
+++ b/cmd/strings2/templates/kebab_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/lowercamel_usage.txt
+++ b/cmd/strings2/templates/lowercamel_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/parts_usage.txt
+++ b/cmd/strings2/templates/parts_usage.txt
@@ -6,12 +6,13 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json                   (default: false)   Output as JSON
-    --delimiter, -d string                      Delimiter
-    --number-splitting       (default: false)   Enable number splitting
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json                                   (default: false)   Output as JSON
+    --delimiter, -d string                                      Delimiter
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/pascal_usage.txt
+++ b/cmd/strings2/templates/pascal_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/screamingdelimited_usage.txt
+++ b/cmd/strings2/templates/screamingdelimited_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string         (default: ".")     Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                   (default: ".")     Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/screamingkebab_usage.txt
+++ b/cmd/strings2/templates/screamingkebab_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/screamingsnake_usage.txt
+++ b/cmd/strings2/templates/screamingsnake_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/snake_usage.txt
+++ b/cmd/strings2/templates/snake_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/title_usage.txt
+++ b/cmd/strings2/templates/title_usage.txt
@@ -6,19 +6,20 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --delimiter, -d string                            Delimiter
-    --screaming, -S                (default: false)   Screaming mode
-    --whispering, -w               (default: false)   Whispering mode
-    --first-upper, -U              (default: false)   First char upper
-    --first-lower, -l              (default: false)   First char lower
-    --mix-case-support, -m         (default: false)   Mix case support
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --mix-case-support, -m                   (default: false)   Mix case support
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/words_usage.txt
+++ b/cmd/strings2/templates/words_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                                Input file or - for stdin
-    --output, -o string                               Output file or - for stdout
-    --json                         (default: false)   Output as JSON
-    --delimiter, -d string                            Delimiter
-    --no-smart-acronyms            (default: false)   Disable smart acronyms
-    --number-splitting             (default: false)   Enable number splitting
-    --acronym []string             (default: [])      Acronym to preserve case
-    --acronym-from-file []string   (default: [])      File containing acronyms to preserve case
-    --strict                       (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json                                   (default: false)   Output as JSON
+    --delimiter, -d string                                      Delimiter
+    --no-smart-acronyms                      (default: false)   Disable smart acronyms
+    --number-splitting                       (default: false)   Enable number splitting
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --acronym []string                       (default: [])      Acronym to preserve case
+    --acronym-from-file []string             (default: [])      File containing acronyms to preserve case
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstocamel_usage.txt
+++ b/cmd/strings2/templates/wordstocamel_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstodarwin_usage.txt
+++ b/cmd/strings2/templates/wordstodarwin_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstokebab_usage.txt
+++ b/cmd/strings2/templates/wordstokebab_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstopascal_usage.txt
+++ b/cmd/strings2/templates/wordstopascal_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstosnake_usage.txt
+++ b/cmd/strings2/templates/wordstosnake_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/templates/wordstotitle_usage.txt
+++ b/cmd/strings2/templates/wordstotitle_usage.txt
@@ -6,15 +6,16 @@ Subcommands:
     usage        Print this usage message
 
 Flags:
-    --input, -i string                          Input file or - for stdin
-    --output, -o string                         Output file or - for stdout
-    --json-input             (default: false)   Input as JSON
-    --delimiter, -d string                      Delimiter
-    --screaming, -S          (default: false)   Screaming mode
-    --whispering, -w         (default: false)   Whispering mode
-    --first-upper, -U        (default: false)   First char upper
-    --first-lower, -l        (default: false)   First char lower
-    --strict                 (default: false)   Strict UTF8 mode
+    --input, -i string                                          Input file or - for stdin
+    --output, -o string                                         Output file or - for stdout
+    --json-input                             (default: false)   Input as JSON
+    --delimiter, -d string                                      Delimiter
+    --screaming, -S                          (default: false)   Screaming mode
+    --whispering, -w                         (default: false)   Whispering mode
+    --first-upper, -U                        (default: false)   First char upper
+    --first-lower, -l                        (default: false)   First char lower
+    --non-alphanumeric, --alphanumeric, -N   (default: false)   Treat non characters as delimiters
+    --strict                                 (default: false)   Strict UTF8 mode
 
 Positional Arguments:
     args       String to convert if file/stdin not provided

--- a/cmd/strings2/title.go
+++ b/cmd/strings2/title.go
@@ -27,6 +27,7 @@ type Title struct {
 	mixCaseSupport  bool
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -190,6 +191,17 @@ func (c *Title) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -289,12 +301,16 @@ func (c *RootCmd) NewTitle() *Title {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Title) error {
 
-		cli.Title(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Title(c.input, c.output, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.mixCaseSupport, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/title_test.go
+++ b/cmd/strings2/title_test.go
@@ -35,6 +35,7 @@ func TestTitle_Execute(t *testing.T) {
 	args = append(args, "--mixCaseSupport")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -76,6 +77,9 @@ func TestTitle_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/words.go
+++ b/cmd/strings2/words.go
@@ -23,6 +23,7 @@ type Words struct {
 	delimiter       string
 	noSmartAcronyms bool
 	numberSplitting bool
+	nonAlphanumeric bool
 	acronym         []string
 	acronymFromFile []string
 	strict          bool
@@ -142,6 +143,17 @@ func (c *Words) Execute(args []string) error {
 					c.numberSplitting = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "acronym":
 				if !hasValue {
 					if i+1 < len(args) {
@@ -228,12 +240,16 @@ func (c *RootCmd) NewWords() *Words {
 
 	set.BoolVar(&v.numberSplitting, "number-splitting", false, "Enable number splitting")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Words) error {
 
-		cli.Words(c.input, c.output, c.jsonOut, c.delimiter, c.noSmartAcronyms, c.numberSplitting, c.acronym, c.acronymFromFile, c.strict, c.args...)
+		cli.Words(c.input, c.output, c.jsonOut, c.delimiter, c.noSmartAcronyms, c.numberSplitting, c.nonAlphanumeric, c.acronym, c.acronymFromFile, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/words_test.go
+++ b/cmd/strings2/words_test.go
@@ -31,6 +31,7 @@ func TestWords_Execute(t *testing.T) {
 	args = append(args, "test")
 	args = append(args, "--noSmartAcronyms")
 	args = append(args, "--numberSplitting")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--acronym")
 	args = append(args, "--acronymFromFile")
 	args = append(args, "--strict")
@@ -60,6 +61,9 @@ func TestWords_Execute(t *testing.T) {
 	}
 	if cmd.numberSplitting != true {
 		t.Errorf("Expected numberSplitting to be true, got '%v'", cmd.numberSplitting)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstocamel.go
+++ b/cmd/strings2/wordstocamel.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstocamel)(nil)
 
 type Wordstocamel struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstocamel) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstocamel) error
 }
 
 type UsageDataWordstocamel struct {
@@ -164,6 +165,17 @@ func (c *Wordstocamel) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstocamel() *Wordstocamel {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstocamel) error {
 
-		cli.WordsToCamel(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToCamel(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstocamel_test.go
+++ b/cmd/strings2/wordstocamel_test.go
@@ -33,6 +33,7 @@ func TestWordstocamel_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstocamel_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstodarwin.go
+++ b/cmd/strings2/wordstodarwin.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstodarwin)(nil)
 
 type Wordstodarwin struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstodarwin) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstodarwin) error
 }
 
 type UsageDataWordstodarwin struct {
@@ -164,6 +165,17 @@ func (c *Wordstodarwin) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstodarwin() *Wordstodarwin {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstodarwin) error {
 
-		cli.WordsToDarwin(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToDarwin(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstodarwin_test.go
+++ b/cmd/strings2/wordstodarwin_test.go
@@ -33,6 +33,7 @@ func TestWordstodarwin_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstodarwin_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstokebab.go
+++ b/cmd/strings2/wordstokebab.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstokebab)(nil)
 
 type Wordstokebab struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstokebab) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstokebab) error
 }
 
 type UsageDataWordstokebab struct {
@@ -164,6 +165,17 @@ func (c *Wordstokebab) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstokebab() *Wordstokebab {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstokebab) error {
 
-		cli.WordsToKebab(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToKebab(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstokebab_test.go
+++ b/cmd/strings2/wordstokebab_test.go
@@ -33,6 +33,7 @@ func TestWordstokebab_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstokebab_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstopascal.go
+++ b/cmd/strings2/wordstopascal.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstopascal)(nil)
 
 type Wordstopascal struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstopascal) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstopascal) error
 }
 
 type UsageDataWordstopascal struct {
@@ -164,6 +165,17 @@ func (c *Wordstopascal) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstopascal() *Wordstopascal {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstopascal) error {
 
-		cli.WordsToPascal(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToPascal(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstopascal_test.go
+++ b/cmd/strings2/wordstopascal_test.go
@@ -33,6 +33,7 @@ func TestWordstopascal_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstopascal_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstosnake.go
+++ b/cmd/strings2/wordstosnake.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstosnake)(nil)
 
 type Wordstosnake struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstosnake) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstosnake) error
 }
 
 type UsageDataWordstosnake struct {
@@ -164,6 +165,17 @@ func (c *Wordstosnake) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstosnake() *Wordstosnake {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstosnake) error {
 
-		cli.WordsToSnake(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToSnake(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstosnake_test.go
+++ b/cmd/strings2/wordstosnake_test.go
@@ -33,6 +33,7 @@ func TestWordstosnake_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstosnake_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/cmd/strings2/wordstotitle.go
+++ b/cmd/strings2/wordstotitle.go
@@ -16,19 +16,20 @@ var _ Cmd = (*Wordstotitle)(nil)
 
 type Wordstotitle struct {
 	*RootCmd
-	Flags         *flag.FlagSet
-	input         string
-	output        string
-	jsonInput     bool
-	delimiter     string
-	screaming     bool
-	whispering    bool
-	firstUpper    bool
-	firstLower    bool
-	strict        bool
-	args          []string
-	SubCommands   map[string]Cmd
-	CommandAction func(c *Wordstotitle) error
+	Flags           *flag.FlagSet
+	input           string
+	output          string
+	jsonInput       bool
+	delimiter       string
+	screaming       bool
+	whispering      bool
+	firstUpper      bool
+	firstLower      bool
+	nonAlphanumeric bool
+	strict          bool
+	args            []string
+	SubCommands     map[string]Cmd
+	CommandAction   func(c *Wordstotitle) error
 }
 
 type UsageDataWordstotitle struct {
@@ -164,6 +165,17 @@ func (c *Wordstotitle) Execute(args []string) error {
 					c.firstLower = true
 				}
 
+			case "nonAlphanumeric", "non-alphanumeric", "alphanumeric", "N":
+				if hasValue {
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
+					}
+					c.nonAlphanumeric = b
+				} else {
+					c.nonAlphanumeric = true
+				}
+
 			case "strict":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -236,12 +248,16 @@ func (c *RootCmd) NewWordstotitle() *Wordstotitle {
 	set.BoolVar(&v.firstLower, "first-lower", false, "First char lower")
 	set.BoolVar(&v.firstLower, "l", false, "First char lower")
 
+	set.BoolVar(&v.nonAlphanumeric, "non-alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "alphanumeric", false, "Treat non characters as delimiters")
+	set.BoolVar(&v.nonAlphanumeric, "N", false, "Treat non characters as delimiters")
+
 	set.BoolVar(&v.strict, "strict", false, "Strict UTF8 mode")
 	set.Usage = v.Usage
 
 	v.CommandAction = func(c *Wordstotitle) error {
 
-		cli.WordsToTitle(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.strict, c.args...)
+		cli.WordsToTitle(c.input, c.output, c.jsonInput, c.delimiter, c.screaming, c.whispering, c.firstUpper, c.firstLower, c.nonAlphanumeric, c.strict, c.args...)
 		return nil
 	}
 

--- a/cmd/strings2/wordstotitle_test.go
+++ b/cmd/strings2/wordstotitle_test.go
@@ -33,6 +33,7 @@ func TestWordstotitle_Execute(t *testing.T) {
 	args = append(args, "--whispering")
 	args = append(args, "--firstUpper")
 	args = append(args, "--firstLower")
+	args = append(args, "--nonAlphanumeric")
 	args = append(args, "--strict")
 
 	err := cmd.Execute(args)
@@ -66,6 +67,9 @@ func TestWordstotitle_Execute(t *testing.T) {
 	}
 	if cmd.firstLower != true {
 		t.Errorf("Expected firstLower to be true, got '%v'", cmd.firstLower)
+	}
+	if cmd.nonAlphanumeric != true {
+		t.Errorf("Expected nonAlphanumeric to be true, got '%v'", cmd.nonAlphanumeric)
 	}
 	if cmd.strict != true {
 		t.Errorf("Expected strict to be true, got '%v'", cmd.strict)

--- a/featuresuggestion.md
+++ b/featuresuggestion.md
@@ -1,0 +1,30 @@
+# Feature Suggestion: Unified Delimiter Detector CLI Argument
+
+## Background
+
+Currently, the `strings2` CLI relies on multiple individual boolean flags to control parsing behavior around boundaries and delimiters (e.g., `--number-splitting`, `--non-alphanumeric`). As more rules are added, this approach bloats the CLI arguments and prevents complex, composable logic from being expressed easily by the user.
+
+## Proposal
+
+Instead of individual flags, introduce a unified `--delimiter-detector` argument that accepts a flexible syntax for defining boundaries dynamically.
+
+## Syntax Examples
+
+**Before:**
+```bash
+strings2 camel "hello_world 123 foo" --number-splitting --non-alphanumeric
+```
+
+**After:**
+```bash
+strings2 camel "hello_world 123 foo" --delimiter-detector "any(numeric, whitespace, nonalphanumeric)"
+```
+
+Or for more complex requirements:
+```bash
+strings2 camel "..." --delimiter-detector "union(whitespace, not(tab))"
+```
+
+## Impact
+
+This allows users to pass sophisticated detection rules directly to the `PartitionerConfig.DelimiterDetector` function dynamically at runtime, reducing the need for hardcoded boolean options in both the `strings2` library API and the CLI application itself.

--- a/featuresuggestion.md
+++ b/featuresuggestion.md
@@ -28,3 +28,5 @@ strings2 camel "..." --delimiter-detector "union(whitespace, not(tab))"
 ## Impact
 
 This allows users to pass sophisticated detection rules directly to the `PartitionerConfig.DelimiterDetector` function dynamically at runtime, reducing the need for hardcoded boolean options in both the `strings2` library API and the CLI application itself.
+
+*Tracked in issue: [https://github.com/arran4/strings2/issues/68](https://github.com/arran4/strings2/issues/68)*

--- a/parser.go
+++ b/parser.go
@@ -140,6 +140,8 @@ type ParserConfig struct {
 	NumberMode NumberMode
 	// EmitEmpty controls whether empty parts are emitted for delimiters
 	EmitEmpty bool
+	// NonAlphanumericAsDelimiter controls whether non-alphanumeric characters are treated as delimiters
+	NonAlphanumericAsDelimiter bool
 }
 
 // NumberMode defines the strategy for handling numbers during parsing.
@@ -179,6 +181,18 @@ type ParserEmitEmpty bool
 
 func (b ParserEmitEmpty) Apply(p *ParserConfig) {
 	p.EmitEmpty = bool(b)
+}
+
+// ParserNonAlphanumericAsDelimiter is a typed option for NonAlphanumericAsDelimiter configuration.
+type ParserNonAlphanumericAsDelimiter bool
+
+func (b ParserNonAlphanumericAsDelimiter) Apply(p *ParserConfig) {
+	p.NonAlphanumericAsDelimiter = bool(b)
+}
+
+// WithNonAlphanumericAsDelimiter enables or disables treating non-alphanumeric characters as delimiters.
+func WithNonAlphanumericAsDelimiter(enabled bool) ParserOption {
+	return ParserNonAlphanumericAsDelimiter(enabled)
 }
 
 // WithIgnore configures characters to be ignored during parsing.
@@ -247,16 +261,19 @@ func DetectPartitioner(stats Stats, config ...*ParserConfig) Partitioner {
 
 	numberMode := NumberModeNone
 	emitEmpty := false
+	nonAlphanumeric := false
 	if len(config) > 0 && config[0] != nil {
 		numberMode = config[0].NumberMode
 		emitEmpty = config[0].EmitEmpty
+		nonAlphanumeric = config[0].NonAlphanumericAsDelimiter
 	}
 
 	return NewPartitioner(PartitionerConfig{
-		Delimiters: delimiters,
-		SplitCamel: true,
-		NumberMode: numberMode,
-		EmitEmpty:  emitEmpty,
+		Delimiters:                 delimiters,
+		SplitCamel:                 true,
+		NumberMode:                 numberMode,
+		EmitEmpty:                  emitEmpty,
+		NonAlphanumericAsDelimiter: nonAlphanumeric,
 	})
 }
 
@@ -395,10 +412,11 @@ func ParseDarwinCaseToParts(input string, opts ...any) ([]Part, error) {
 func WithTitleCasePartitioner() ParserOption {
 	return funcParserOption(func(p *ParserConfig) {
 		p.Partitioner = NewPartitioner(PartitionerConfig{
-			Delimiters: map[rune]bool{' ': true},
-			SplitCamel: false,
-			NumberMode: p.NumberMode,
-			EmitEmpty:  p.EmitEmpty,
+			Delimiters:                 map[rune]bool{' ': true},
+			SplitCamel:                 false,
+			NumberMode:                 p.NumberMode,
+			EmitEmpty:                  p.EmitEmpty,
+			NonAlphanumericAsDelimiter: p.NonAlphanumericAsDelimiter,
 		})
 	})
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -194,3 +194,21 @@ func TestExplicitParsers(t *testing.T) {
 		}
 	})
 }
+
+func TestWithNonAlphanumericAsDelimiter(t *testing.T) {
+	input := "hello_world 123!@#fooBar"
+	words, err := strings2.Parse(input, strings2.WithNonAlphanumericAsDelimiter(true))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	res, err := strings2.ToCamelCase(words)
+	if err != nil {
+		t.Fatalf("ToCamelCase failed: %v", err)
+	}
+
+	expected := "helloWorld123FooBar"
+	if res != expected {
+		t.Errorf("Expected %q, got %q", expected, res)
+	}
+}

--- a/parts.go
+++ b/parts.go
@@ -48,6 +48,8 @@ func overridePartitionerConfig(pcfg *PartitionerConfig, opts ...any) {
 			pcfg.NumberMode = o
 		case ParserEmitEmpty:
 			pcfg.EmitEmpty = bool(o)
+		case ParserNonAlphanumericAsDelimiter:
+			pcfg.NonAlphanumericAsDelimiter = bool(o)
 		}
 	}
 }
@@ -93,10 +95,11 @@ func WithSnakeCasePartitioner(opts ...any) ParserOption {
 			return
 		}
 		pcfg := PartitionerConfig{
-			Delimiters: map[rune]bool{'_': true},
-			SplitCamel: true,
-			NumberMode: cfg.NumberMode,
-			EmitEmpty:  cfg.EmitEmpty,
+			Delimiters:                 map[rune]bool{'_': true},
+			SplitCamel:                 true,
+			NumberMode:                 cfg.NumberMode,
+			EmitEmpty:                  cfg.EmitEmpty,
+			NonAlphanumericAsDelimiter: cfg.NonAlphanumericAsDelimiter,
 		}
 		overridePartitionerConfig(&pcfg, opts...)
 		cfg.Partitioner = NewPartitioner(pcfg)
@@ -110,10 +113,11 @@ func WithKebabCasePartitioner(opts ...any) ParserOption {
 			return
 		}
 		pcfg := PartitionerConfig{
-			Delimiters: map[rune]bool{'-': true},
-			SplitCamel: true,
-			NumberMode: cfg.NumberMode,
-			EmitEmpty:  cfg.EmitEmpty,
+			Delimiters:                 map[rune]bool{'-': true},
+			SplitCamel:                 true,
+			NumberMode:                 cfg.NumberMode,
+			EmitEmpty:                  cfg.EmitEmpty,
+			NonAlphanumericAsDelimiter: cfg.NonAlphanumericAsDelimiter,
 		}
 		overridePartitionerConfig(&pcfg, opts...)
 		cfg.Partitioner = NewPartitioner(pcfg)
@@ -127,10 +131,11 @@ func WithSplitByDelimiter(delim rune, opts ...any) ParserOption {
 			return
 		}
 		pcfg := PartitionerConfig{
-			Delimiters: map[rune]bool{delim: true},
-			SplitCamel: true,
-			NumberMode: cfg.NumberMode,
-			EmitEmpty:  cfg.EmitEmpty,
+			Delimiters:                 map[rune]bool{delim: true},
+			SplitCamel:                 true,
+			NumberMode:                 cfg.NumberMode,
+			EmitEmpty:                  cfg.EmitEmpty,
+			NonAlphanumericAsDelimiter: cfg.NonAlphanumericAsDelimiter,
 		}
 		overridePartitionerConfig(&pcfg, opts...)
 		cfg.Partitioner = NewPartitioner(pcfg)
@@ -144,9 +149,10 @@ func WithCamelCasePartitioner(opts ...any) ParserOption {
 			return
 		}
 		pcfg := PartitionerConfig{
-			SplitCamel: true,
-			NumberMode: cfg.NumberMode,
-			EmitEmpty:  cfg.EmitEmpty,
+			SplitCamel:                 true,
+			NumberMode:                 cfg.NumberMode,
+			EmitEmpty:                  cfg.EmitEmpty,
+			NonAlphanumericAsDelimiter: cfg.NonAlphanumericAsDelimiter,
 		}
 		overridePartitionerConfig(&pcfg, opts...)
 		cfg.Partitioner = NewPartitioner(pcfg)
@@ -159,10 +165,11 @@ func WithCamelCasePartitioner(opts ...any) ParserOption {
 type DelimiterDetector func(subs []SubPart, index int) (length int)
 
 type PartitionerConfig struct {
-	Ignore string
-	Delimiters        map[rune]bool
-	DelimiterDetector DelimiterDetector
-	SplitCamel        bool
+	Ignore                     string
+	Delimiters                 map[rune]bool
+	DelimiterDetector          DelimiterDetector
+	SplitCamel                 bool
+	NonAlphanumericAsDelimiter bool // If true, treats any non-alphanumeric character as a delimiter
 
 	NumberMode  NumberMode
 	PreserveSep bool // If true, delimiters are returned as SeparatorPart instead of discarded
@@ -192,6 +199,9 @@ func NewPartitioner(cfg PartitionerConfig) Partitioner {
 					}
 				}
 				if delimLen == 0 && cfg.Delimiters != nil && cfg.Delimiters[s.Rune()] {
+					delimLen = 1
+				}
+				if delimLen == 0 && cfg.NonAlphanumericAsDelimiter && !s.IsLetter() && !s.IsDigit() {
 					delimLen = 1
 				}
 			}


### PR DESCRIPTION
Implemented a feature to native strip non-alphanumeric characters during parsing and formatting.

*   Added `NonAlphanumericAsDelimiter` to `ParserConfig` and `PartitionerConfig`.
*   Created `WithNonAlphanumericAsDelimiter(bool)` parsing option.
*   Updated the parser to detect and treat non-letters and non-digits as delimiters when enabled.
*   Updated all CLI formatting commands to accept a new `-N` (`--non-alphanumeric`) flag.
*   Regenerated CLI command files.
*   Added `TestWithNonAlphanumericAsDelimiter` to verify functionality.

---
*PR created automatically by Jules for task [9313176761616089840](https://jules.google.com/task/9313176761616089840) started by @arran4*